### PR TITLE
feat:CO-21 : container query instead of media query

### DIFF
--- a/public/demo.html
+++ b/public/demo.html
@@ -10,34 +10,39 @@
     <!-- This demo file is used to test both the production bundles after running yarn build -->
     <h1>Humm widgets cards online</h1>
 
-    <h2>AU default widget</h2>
-    <script src="./humm-widgets-cards-au.umd.js?productPrice=400&merchantId='aaa143af-a96b-4887-bcd2-85960da544ea'"></script>
+    <div
+      class="resizeWidget"
+      style="resize: horizontal; overflow: auto; width: fit-content"
+    >
+      <h2>AU default widget</h2>
+      <script src="./humm-widgets-cards-au.umd.js?productPrice=400&merchantId='aaa143af-a96b-4887-bcd2-85960da544ea'"></script>
 
-    <h2>AU default dark widget</h2>
-    <script src="./humm-widgets-cards-au.umd.js?productPrice=400&merchantId='2b1bd959-5c95-45d7-9365-5844e270a2b6'&darkMode='true'"></script>
+      <h2>AU default dark widget</h2>
+      <script src="./humm-widgets-cards-au.umd.js?productPrice=400&merchantId='2b1bd959-5c95-45d7-9365-5844e270a2b6'&darkMode='true'"></script>
 
-    <h2>AU blank widget (remove other widgets to see this in action)</h2>
-    <script src="./humm-widgets-cards-au.umd.js?productPrice=400&merchantId='fc02c112-e8dd-49ee-bb8f-ab706c8df80f'&removeCss='true'"></script>
+      <h2>AU blank widget (remove other widgets to see this in action)</h2>
+      <script src="./humm-widgets-cards-au.umd.js?productPrice=400&merchantId='fc02c112-e8dd-49ee-bb8f-ab706c8df80f'&removeCss='true'"></script>
 
-    <h2>NZ default widget</h2>
-    <script src="./humm-widgets-cards-nz.umd.js?productPrice=300&merchantId='8ea286eb-b884-4518-8fa1-b65a107a350d'"></script>
+      <h2>NZ default widget</h2>
+      <script src="./humm-widgets-cards-nz.umd.js?productPrice=300&merchantId='8ea286eb-b884-4518-8fa1-b65a107a350d'"></script>
 
-    <h2>NZ default dark widget</h2>
-    <script src="./humm-widgets-cards-nz.umd.js?productPrice=300&merchantId='a1d8405f-8b3b-4300-b845-5c265957d83e'&darkMode='true'"></script>
+      <h2>NZ default dark widget</h2>
+      <script src="./humm-widgets-cards-nz.umd.js?productPrice=300&merchantId='a1d8405f-8b3b-4300-b845-5c265957d83e'&darkMode='true'"></script>
 
-    <h2>NZ Q Mastercard widget</h2>
-    <script src="./humm-widgets-cards-nz.umd.js?productPrice=300&merchantId='007c6a4c-5182-471e-81fe-3a8990485892'&theme='qmc'"></script>
+      <h2>NZ Q Mastercard widget</h2>
+      <script src="./humm-widgets-cards-nz.umd.js?productPrice=300&merchantId='007c6a4c-5182-471e-81fe-3a8990485892'&theme='qmc'"></script>
 
-    <h2>NZ Q Mastercard dark widget</h2>
-    <script src="./humm-widgets-cards-nz.umd.js?productPrice=300&merchantId='a9cb5441-0672-4583-9573-663b33fc72cf'&theme='qmc'&darkMode='true'"></script>
+      <h2>NZ Q Mastercard dark widget</h2>
+      <script src="./humm-widgets-cards-nz.umd.js?productPrice=300&merchantId='a9cb5441-0672-4583-9573-663b33fc72cf'&theme='qmc'&darkMode='true'"></script>
 
-    <h2>NZ Farmers widget</h2>
-    <script src="./humm-widgets-cards-nz.umd.js?productPrice=300&merchantId='09ce684d-cba6-44fb-a47c-77401f343be1'&theme='farmers'"></script>
+      <h2>NZ Farmers widget</h2>
+      <script src="./humm-widgets-cards-nz.umd.js?productPrice=300&merchantId='09ce684d-cba6-44fb-a47c-77401f343be1'&theme='farmers'"></script>
 
-    <h2>NZ Humm Group widget</h2>
-    <script src="./humm-widgets-cards-nz.umd.js?productPrice=300&merchantId='260a994e-b577-44ca-af6c-76a538386d27'&theme='hummgroup'"></script>
+      <h2>NZ Humm Group widget</h2>
+      <script src="./humm-widgets-cards-nz.umd.js?productPrice=300&merchantId='260a994e-b577-44ca-af6c-76a538386d27'&theme='hummgroup'"></script>
 
-    <h2>NZ blank widget (remove other widgets to see this in action)</h2>
-    <script src="./humm-widgets-cards-nz.umd.js?productPrice=300&merchantId='aa7844ff-c24c-4087-8e9e-534eb59a9a18'&removeCss='true'"></script>
+      <h2>NZ blank widget (remove other widgets to see this in action)</h2>
+      <script src="./humm-widgets-cards-nz.umd.js?productPrice=300&merchantId='aa7844ff-c24c-4087-8e9e-534eb59a9a18'&removeCss='true'"></script>
+    </div>
   </body>
 </html>

--- a/src/App-au.vue
+++ b/src/App-au.vue
@@ -1,20 +1,26 @@
 <template>
   <Theme :lang="lang" :theme="theme" :is-dark="darkMode">
-    <component
-      :is="currentWidget"
-      :product-price="productPrice"
-      :lang="lang"
-      :theme="theme"
-      :cards="cards"
-      :products="products"
-      :terms="terms"
-    />
+    <Responsive>
+      <template #default="{ isSizeLarge }">
+        <component
+          :is="currentWidget"
+          :product-price="productPrice"
+          :lang="lang"
+          :theme="theme"
+          :is-size-large="isSizeLarge"
+          :cards="cards"
+          :products="products"
+          :terms="terms"
+        />
+      </template>
+    </Responsive>
   </Theme>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue'
 import Theme from 'src/providers/Theme.vue'
+import Responsive from 'src/providers/Responsive.vue'
 import WidgetMainHumm90 from 'src/widgets/WidgetMainHumm90.vue'
 import LanguageCodeEnum from 'src/models/enums/LanguageCodeEnum'
 import ThemeEnum from 'src/models/enums/ThemeEnum'
@@ -27,6 +33,7 @@ export default defineComponent({
   name: 'App',
   components: {
     Theme,
+    Responsive,
   },
   props: {
     productPrice: Number,

--- a/src/App-nz.vue
+++ b/src/App-nz.vue
@@ -1,20 +1,26 @@
 <template>
   <Theme :lang="lang" :theme="theme" :is-dark="darkMode">
-    <component
-      :is="currentWidget"
-      :product-price="productPrice"
-      :lang="lang"
-      :theme="theme"
-      :cards="cards"
-      :products="products"
-      :terms="terms"
-    />
+    <Responsive>
+      <template #default="{ isSizeLarge }">
+        <component
+          :is="currentWidget"
+          :product-price="productPrice"
+          :lang="lang"
+          :theme="theme"
+          :is-size-large="isSizeLarge"
+          :cards="cards"
+          :products="products"
+          :terms="terms"
+        />
+      </template>
+    </Responsive>
   </Theme>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue'
 import Theme from 'src/providers/Theme.vue'
+import Responsive from 'src/providers/Responsive.vue'
 import WidgetMainQmc from 'src/widgets/WidgetMainQmc.vue'
 import WidgetMainFarmers from 'src/widgets/WidgetMainFarmers.vue'
 import WidgetMainHummGroup from 'src/widgets/WidgetMainHummGroup.vue'
@@ -29,6 +35,7 @@ export default defineComponent({
   name: 'App',
   components: {
     Theme,
+    Responsive,
   },
   props: {
     productPrice: Number,

--- a/src/components/buttons/Button.vue
+++ b/src/components/buttons/Button.vue
@@ -90,17 +90,12 @@ export default defineComponent({
 
   &--auto {
     min-height: 35px;
-    width: 100%;
-    max-width: 138px;
-
-    @media (min-width: 430px) {
-      letter-spacing: -0.01em;
-      font-size: 12px;
-      font-weight: 500;
-      width: auto;
-      min-width: 90px;
-      min-height: 20px;
-    }
+    letter-spacing: -0.01em;
+    font-size: 12px;
+    font-weight: 500;
+    width: auto;
+    min-width: 90px;
+    min-height: 20px;
   }
 
   &--sm {

--- a/src/components/dataDisplay/Card.vue
+++ b/src/components/dataDisplay/Card.vue
@@ -28,10 +28,6 @@ export default defineComponent({
 
   &--auto {
     width: 34px;
-
-    @media (min-width: 430px) {
-      width: 35px;
-    }
   }
 
   &--sm {

--- a/src/components/dialog/Dialog.vue
+++ b/src/components/dialog/Dialog.vue
@@ -161,10 +161,6 @@ export default defineComponent({
     font-family: var(--font-base);
     pointer-events: all;
     color: var(--color-0);
-
-    @media (min-width: 560px) {
-      max-width: 536px;
-    }
   }
 
   &__title {

--- a/src/components/dialog/Dialog.vue
+++ b/src/components/dialog/Dialog.vue
@@ -161,6 +161,10 @@ export default defineComponent({
     font-family: var(--font-base);
     pointer-events: all;
     color: var(--color-0);
+
+    @media (min-width: 560px) {
+      max-width: 536px;
+    }
   }
 
   &__title {

--- a/src/modules/WidgetContent.vue
+++ b/src/modules/WidgetContent.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="isWidgetOpen" class="widget">
+  <div v-if="isWidgetOpen" :data-size-large="isSizeLarge" class="widget">
     <div class="widget__content">
       <slot name="logo" />
       <div class="widget__container">
@@ -44,6 +44,7 @@ export default defineComponent({
       type: Boolean,
       required: true,
     },
+    isSizeLarge: Boolean,
     buttonLabel: {
       type: String,
       default: 'Learn More',

--- a/src/providers/Responsive.vue
+++ b/src/providers/Responsive.vue
@@ -1,0 +1,50 @@
+<template v-slot:default="slotProps">
+  <div ref="box" class="box">
+    <slot :isSizeLarge="isSizeLarge"></slot>
+    <div>{{ width }}</div>
+    <div>{{ isSizeLarge }}</div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+export default defineComponent({
+  name: 'Responsive',
+  emits: ['resize'],
+  data() {
+    return {
+      width: 0,
+      isSizeLarge: false,
+      observer: {} as ResizeObserver,
+    }
+  },
+  mounted() {
+    // initialize the observer on mount
+    this.initObserver()
+  },
+  beforeUnmount() {
+    if (this.observer) this.observer?.unobserve(this.$refs.box as Element)
+  },
+  methods: {
+    onResize() {
+      const box = this.$refs.box as Element
+      const width = box.clientWidth
+      this.width = width
+
+      if (width > 410) {
+        this.isSizeLarge = true
+      } else {
+        this.isSizeLarge = false
+      }
+
+      // Optionally, emit event with dimensions
+      this.$emit('resize', { width })
+    },
+    initObserver() {
+      const observer = new ResizeObserver(this.onResize)
+      observer.observe(this.$refs.box as Element)
+      this.observer = observer
+    },
+  },
+})
+</script>

--- a/src/providers/Responsive.vue
+++ b/src/providers/Responsive.vue
@@ -8,7 +8,6 @@
 import { defineComponent } from 'vue'
 export default defineComponent({
   name: 'Responsive',
-  emits: ['resize'],
   data() {
     return {
       width: 0,
@@ -26,17 +25,7 @@ export default defineComponent({
   methods: {
     onResize() {
       const box = this.$refs.box as Element
-      const width = box.clientWidth
-      this.width = width
-
-      if (width > 410) {
-        this.isSizeLarge = true
-      } else {
-        this.isSizeLarge = false
-      }
-
-      // Optionally, emit event with dimensions
-      this.$emit('resize', { width })
+      this.isSizeLarge = box.clientWidth > 410
     },
     initObserver() {
       const observer = new ResizeObserver(this.onResize)

--- a/src/providers/Responsive.vue
+++ b/src/providers/Responsive.vue
@@ -1,8 +1,6 @@
 <template v-slot:default="slotProps">
   <div ref="box" class="box">
     <slot :isSizeLarge="isSizeLarge"></slot>
-    <div>{{ width }}</div>
-    <div>{{ isSizeLarge }}</div>
   </div>
 </template>
 

--- a/src/styles/cards.scss
+++ b/src/styles/cards.scss
@@ -21,12 +21,8 @@
   }
 
   &--logo {
-    width: 75px;
+    min-width: 75px;
     margin-top: 3px;
-
-    @media (min-width: 430px) {
-      width: 107px;
-    }
   }
 
   &__products {

--- a/src/styles/widget.scss
+++ b/src/styles/widget.scss
@@ -7,7 +7,7 @@
   position: relative;
   filter: drop-shadow(0 1px 5px rgba(0, 0, 0, 0.1));
 
-  @media (min-width: 430px) {
+  [data-size-large='true'] & {
     display: flex;
     padding: 10px 12px;
     max-width: 436px;
@@ -23,7 +23,7 @@
     display: block;
     margin-left: 8px;
 
-    @media (min-width: 430px) {
+    [data-size-large='true'] & {
       display: flex;
       align-items: flex-start;
       width: 100%;
@@ -64,7 +64,7 @@
   &__hummgroup {
     width: 72px;
 
-    @media (min-width: 430px) {
+    [data-size-large='true'] & {
       width: 100px;
       margin: 11px 0 0 0;
     }

--- a/src/styles/widget.scss
+++ b/src/styles/widget.scss
@@ -7,7 +7,7 @@
   position: relative;
   filter: drop-shadow(0 1px 5px rgba(0, 0, 0, 0.1));
 
-  [data-size-large='true'] & {
+  &[data-size-large='true'] {
     display: flex;
     padding: 10px 12px;
     max-width: 436px;
@@ -23,17 +23,17 @@
     display: block;
     margin-left: 8px;
 
-    [data-size-large='true'] & {
-      display: flex;
-      align-items: flex-start;
-      width: 100%;
-      justify-content: space-between;
-      margin-right: 8px;
-    }
-
     .button {
       margin-top: 4px;
     }
+  }
+
+  &[data-size-large='true'] &__container {
+    display: flex;
+    align-items: flex-start;
+    width: 100%;
+    justify-content: space-between;
+    margin-right: 8px;
   }
 
   &__text {
@@ -63,11 +63,11 @@
 
   &__hummgroup {
     width: 72px;
+  }
 
-    [data-size-large='true'] & {
-      width: 100px;
-      margin: 11px 0 0 0;
-    }
+  &[data-size-large='true'] &__hummgroup {
+    width: 100px;
+    margin: 11px 0 0 0;
   }
 
   &__close {

--- a/src/widgets/WidgetMainFarmers.vue
+++ b/src/widgets/WidgetMainFarmers.vue
@@ -1,5 +1,6 @@
 <template>
   <WidgetContent
+    :is-size-large="isSizeLarge"
     :is-widget-open="isWidgetOpen"
     @toggle-dialog="isDialogOpen = true"
     @close-widget="isWidgetOpen = false"
@@ -20,6 +21,7 @@
       <span class="widget__subtitle">Indicative Payments. Ts&Cs Apply.</span>
     </template>
   </WidgetContent>
+  <div>isSizeLarge: {{ isSizeLarge }}</div>
 
   <DialogOverlay
     id="widget-dialog"
@@ -54,6 +56,10 @@ export default defineComponent({
     productPrice: Number,
     lang: String as () => LanguageCodeEnum,
     theme: String as () => ThemeEnum,
+    isSizeLarge: {
+      type: Boolean,
+      required: true,
+    },
     cards: {
       type: Array as () => CardProps[],
       required: true,

--- a/src/widgets/WidgetMainFarmers.vue
+++ b/src/widgets/WidgetMainFarmers.vue
@@ -21,7 +21,6 @@
       <span class="widget__subtitle">Indicative Payments. Ts&Cs Apply.</span>
     </template>
   </WidgetContent>
-  <div>isSizeLarge: {{ isSizeLarge }}</div>
 
   <DialogOverlay
     id="widget-dialog"

--- a/src/widgets/WidgetMainHumm90.vue
+++ b/src/widgets/WidgetMainHumm90.vue
@@ -1,29 +1,25 @@
 <template>
-  <div :data-size-large="isSizeLarge">
-    <WidgetContent
-      :data-size-large="isSizeLarge"
-      :is-widget-open="isWidgetOpen"
-      button-color="var(--color-3)"
-      icon-opacity="0.3"
-      button-label="LEARN MORE"
-      @toggle-dialog="isDialogOpen = true"
-      @close-widget="isWidgetOpen = false"
-    >
-      <template #logo>
-        <div class="widget__iconbird">
-          <IconHumm90Bird fill="var(--color-1-contrast)" />
-        </div>
-      </template>
-      <template #title>
-        <p class="widget__title">UP TO 60 MONTHS INTEREST-FREE.</p>
-      </template>
-      <template #subtitle>
-        <span class="widget__subtitle">
-          Indicative Payments. Ts&Cs Apply.
-        </span>
-      </template>
-    </WidgetContent>
-  </div>
+  <WidgetContent
+    :is-size-large="isSizeLarge"
+    :is-widget-open="isWidgetOpen"
+    button-color="var(--color-3)"
+    icon-opacity="0.3"
+    button-label="LEARN MORE"
+    @toggle-dialog="isDialogOpen = true"
+    @close-widget="isWidgetOpen = false"
+  >
+    <template #logo>
+      <div class="widget__iconbird">
+        <IconHumm90Bird fill="var(--color-1-contrast)" />
+      </div>
+    </template>
+    <template #title>
+      <p class="widget__title">UP TO 60 MONTHS INTEREST-FREE.</p>
+    </template>
+    <template #subtitle>
+      <span class="widget__subtitle"> Indicative Payments. Ts&Cs Apply. </span>
+    </template>
+  </WidgetContent>
   <div>isSizeLarge: {{ isSizeLarge }}</div>
 
   <DialogOverlay

--- a/src/widgets/WidgetMainHumm90.vue
+++ b/src/widgets/WidgetMainHumm90.vue
@@ -1,6 +1,7 @@
 <template>
-  <div ref="box" class="box" :data-size-large="isSizeLarge">
+  <div :data-size-large="isSizeLarge">
     <WidgetContent
+      :data-size-large="isSizeLarge"
       :is-widget-open="isWidgetOpen"
       button-color="var(--color-3)"
       icon-opacity="0.3"
@@ -22,8 +23,8 @@
         </span>
       </template>
     </WidgetContent>
-    <div>width: {{ width }}</div>
   </div>
+  <div>isSizeLarge: {{ isSizeLarge }}</div>
 
   <DialogOverlay
     id="widget-dialog"
@@ -88,6 +89,10 @@ export default defineComponent({
     productPrice: Number,
     lang: String as () => LanguageCodeEnum,
     theme: String as () => ThemeEnum,
+    isSizeLarge: {
+      type: Boolean,
+      required: true,
+    },
     cards: {
       type: Array as () => CardProps[],
       required: true,
@@ -101,52 +106,17 @@ export default defineComponent({
       required: true,
     },
   },
-  emits: ['resize'],
   data() {
     return {
       isWidgetOpen: true,
       isDialogOpen: false,
       buttonCloseLabel: 'Close',
       Theme: ThemeEnum,
-      width: 0,
-      isSizeLarge: undefined,
-      observer: {} as ResizeObserver,
     }
   },
   computed: {
     getApplyCards(): CardProps[] {
       return this.cards.slice(0, 1)
-    },
-  },
-  mounted() {
-    // initialize the observer on mount
-    this.initObserver()
-  },
-  beforeUnmount() {
-    if (this.observer) this.observer?.unobserve(this.$refs.box as Element)
-  },
-  methods: {
-    onResize() {
-      const box = this.$refs.box as Element
-      console.log({ box })
-      const width = box.clientWidth
-
-      this.width = width
-      console.log({ width })
-
-      if (width > 410) {
-        this.isSizeLarge = true
-      } else {
-        this.isSizeLarge = false
-      }
-
-      // Optionally, emit event with dimensions
-      this.$emit('resize', { width })
-    },
-    initObserver() {
-      const observer = new ResizeObserver(this.onResize)
-      observer.observe(this.$refs.box as Element)
-      this.observer = observer
     },
   },
 })

--- a/src/widgets/WidgetMainHumm90.vue
+++ b/src/widgets/WidgetMainHumm90.vue
@@ -1,24 +1,30 @@
 <template>
-  <WidgetContent
-    :is-widget-open="isWidgetOpen"
-    button-color="var(--color-3)"
-    icon-opacity="0.3"
-    button-label="LEARN MORE"
-    @toggle-dialog="isDialogOpen = true"
-    @close-widget="isWidgetOpen = false"
-  >
-    <template #logo>
-      <div class="widget__iconbird">
-        <IconHumm90Bird fill="var(--color-1-contrast)" />
-      </div>
-    </template>
-    <template #title>
-      <p class="widget__title">UP TO 60 MONTHS INTEREST-FREE.</p>
-    </template>
-    <template #subtitle>
-      <span class="widget__subtitle">Indicative Payments. Ts&Cs Apply.</span>
-    </template>
-  </WidgetContent>
+  <div ref="box" class="box">
+    <WidgetContent
+      :is-widget-open="isWidgetOpen"
+      button-color="var(--color-3)"
+      icon-opacity="0.3"
+      button-label="LEARN MORE"
+      @toggle-dialog="isDialogOpen = true"
+      @close-widget="isWidgetOpen = false"
+    >
+      <template #logo>
+        <div class="widget__iconbird">
+          <IconHumm90Bird fill="var(--color-1-contrast)" />
+        </div>
+      </template>
+      <template #title>
+        <p class="widget__title">UP TO 60 MONTHS INTEREST-FREE.</p>
+      </template>
+      <template #subtitle>
+        <span class="widget__subtitle">
+          Indicative Payments. Ts&Cs Apply.
+        </span>
+      </template>
+    </WidgetContent>
+    <div>width: {{ width }}</div>
+    <div>height: {{ height }}</div>
+  </div>
 
   <DialogOverlay
     id="widget-dialog"
@@ -96,17 +102,48 @@ export default defineComponent({
       required: true,
     },
   },
+  emits: ['resize'],
   data() {
     return {
       isWidgetOpen: true,
       isDialogOpen: false,
       buttonCloseLabel: 'Close',
       Theme: ThemeEnum,
+      width: null,
+      height: null,
+      observer: {},
     }
   },
   computed: {
     getApplyCards(): CardProps[] {
       return this.cards.slice(0, 1)
+    },
+  },
+  mounted() {
+    // initialize the observer on mount
+    this.initObserver()
+  },
+  beforeUnmount() {
+    if (this.observer) this.observer?.unobserve(this.$refs.box)
+  },
+  methods: {
+    onResize() {
+      const box = this.$refs.box
+      console.log({ box })
+      const width = (box as any).clientWidth
+      const height = (box as any).clientHeight
+
+      this.width = width
+      this.height = height
+      console.log({ width })
+      console.log({ height })
+      // Optionally, emit event with dimensions
+      this.$emit('resize', { width, height })
+    },
+    initObserver() {
+      const observer = new ResizeObserver(this.onResize)
+      observer.observe(this.$refs.box as Element)
+      this.observer = observer
     },
   },
 })

--- a/src/widgets/WidgetMainHumm90.vue
+++ b/src/widgets/WidgetMainHumm90.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="box" class="box">
+  <div ref="box" class="box" :data-size-large="isSizeLarge">
     <WidgetContent
       :is-widget-open="isWidgetOpen"
       button-color="var(--color-3)"
@@ -23,7 +23,6 @@
       </template>
     </WidgetContent>
     <div>width: {{ width }}</div>
-    <div>height: {{ height }}</div>
   </div>
 
   <DialogOverlay
@@ -110,7 +109,7 @@ export default defineComponent({
       buttonCloseLabel: 'Close',
       Theme: ThemeEnum,
       width: 0,
-      height: 0,
+      isSizeLarge: undefined,
       observer: {} as ResizeObserver,
     }
   },
@@ -131,14 +130,18 @@ export default defineComponent({
       const box = this.$refs.box as Element
       console.log({ box })
       const width = box.clientWidth
-      const height = box.clientHeight
 
       this.width = width
-      this.height = height
       console.log({ width })
-      console.log({ height })
+
+      if (width > 410) {
+        this.isSizeLarge = true
+      } else {
+        this.isSizeLarge = false
+      }
+
       // Optionally, emit event with dimensions
-      this.$emit('resize', { width, height })
+      this.$emit('resize', { width })
     },
     initObserver() {
       const observer = new ResizeObserver(this.onResize)

--- a/src/widgets/WidgetMainHumm90.vue
+++ b/src/widgets/WidgetMainHumm90.vue
@@ -109,9 +109,9 @@ export default defineComponent({
       isDialogOpen: false,
       buttonCloseLabel: 'Close',
       Theme: ThemeEnum,
-      width: null,
-      height: null,
-      observer: {},
+      width: 0,
+      height: 0,
+      observer: {} as ResizeObserver,
     }
   },
   computed: {
@@ -124,14 +124,14 @@ export default defineComponent({
     this.initObserver()
   },
   beforeUnmount() {
-    if (this.observer) this.observer?.unobserve(this.$refs.box)
+    if (this.observer) this.observer?.unobserve(this.$refs.box as Element)
   },
   methods: {
     onResize() {
-      const box = this.$refs.box
+      const box = this.$refs.box as Element
       console.log({ box })
-      const width = (box as any).clientWidth
-      const height = (box as any).clientHeight
+      const width = box.clientWidth
+      const height = box.clientHeight
 
       this.width = width
       this.height = height

--- a/src/widgets/WidgetMainHumm90.vue
+++ b/src/widgets/WidgetMainHumm90.vue
@@ -20,7 +20,6 @@
       <span class="widget__subtitle"> Indicative Payments. Ts&Cs Apply. </span>
     </template>
   </WidgetContent>
-  <div>isSizeLarge: {{ isSizeLarge }}</div>
 
   <DialogOverlay
     id="widget-dialog"

--- a/src/widgets/WidgetMainHummGroup.vue
+++ b/src/widgets/WidgetMainHummGroup.vue
@@ -1,5 +1,6 @@
 <template>
   <WidgetContent
+    :is-size-large="isSizeLarge"
     :is-widget-open="isWidgetOpen"
     @toggle-dialog="isDialogOpen = true"
     @close-widget="isWidgetOpen = false"
@@ -18,6 +19,7 @@
       <span class="widget__subtitle">Indicative Payments. Ts&Cs Apply.</span>
     </template>
   </WidgetContent>
+  <div>isSizeLarge: {{ isSizeLarge }}</div>
 
   <DialogOverlay
     id="widget-dialog"
@@ -51,6 +53,10 @@ export default defineComponent({
     productPrice: Number,
     lang: String as () => LanguageCodeEnum,
     theme: String as () => ThemeEnum,
+    isSizeLarge: {
+      type: Boolean,
+      required: true,
+    },
     cards: {
       type: Array as () => CardProps[],
       required: true,

--- a/src/widgets/WidgetMainHummGroup.vue
+++ b/src/widgets/WidgetMainHummGroup.vue
@@ -19,7 +19,6 @@
       <span class="widget__subtitle">Indicative Payments. Ts&Cs Apply.</span>
     </template>
   </WidgetContent>
-  <div>isSizeLarge: {{ isSizeLarge }}</div>
 
   <DialogOverlay
     id="widget-dialog"

--- a/src/widgets/WidgetMainQmc.vue
+++ b/src/widgets/WidgetMainQmc.vue
@@ -1,5 +1,6 @@
 <template>
   <WidgetContent
+    :is-size-large="isSizeLarge"
     :is-widget-open="isWidgetOpen"
     :is-button-bold="true"
     button-color="var(--color-3)"
@@ -23,6 +24,7 @@
       <span class="widget__subtitle">T&Cs Apply.</span>
     </template>
   </WidgetContent>
+  <div>isSizeLarge: {{ isSizeLarge }}</div>
 
   <DialogOverlay
     id="widget-dialog"
@@ -80,6 +82,10 @@ export default defineComponent({
     theme: String as () => ThemeEnum,
     cards: {
       type: Array as () => CardProps[],
+      required: true,
+    },
+    isSizeLarge: {
+      type: Boolean,
       required: true,
     },
     products: {

--- a/src/widgets/WidgetMainQmc.vue
+++ b/src/widgets/WidgetMainQmc.vue
@@ -24,7 +24,6 @@
       <span class="widget__subtitle">T&Cs Apply.</span>
     </template>
   </WidgetContent>
-  <div>isSizeLarge: {{ isSizeLarge }}</div>
 
   <DialogOverlay
     id="widget-dialog"


### PR DESCRIPTION
## PR Area

<!-- Check areas your PR covers using "x", REMOVE others -->

- [x] Frontend

## Type of change

_What kind of change does this PR introduce?_

<!-- Check the ones that apply to this PR using "x", REMOVE others -->

- [x] Feature

## Description

<!-- Add a few bullets * describing your changes -->
Problem: The widget is intended to be embedded into a div container of unknown width on the merchant website. The original widget responsive design was based on the overall width of the view port. This design caused the widget to not be rendered correctly when it is embedded in a small merchant container.
Solution: Instead of using view port width as a reference to trigger responsive design, use parent container width.

## Security & risks

<!-- Describe the risks that apply. -->

- [ ] Adds new third party libraries
- [ ] Adds new `.env` variables
- [ ] Integrates with Third-party apis (dependency must be resilient)
- [ ] Has specific [OWASP security concerns](https://owasp.org/www-project-top-ten/) - list them: (also see [Fixing OWASP Top 10](https://nodegoat.herokuapp.com/tutorial))

## Pre-publish checklist

<!--
Include the Jira ticket name (if any) with a hyphen.

If the change spans across multiple packages, please include the general scope area: frontend/backend.
If the change spans across multiple scopes just include the word "multiple" into the scope
-->

- [x] I have assigned myself to the ticket
- [x] I have performed a self-review of my code
- [x] I have performed relevant browser testing
- [ ] I have performed keyboard testing of new or modified interactive components

#### Evidence screenshots

<!-- Please drag and drop to upload evidence screenshots of UI that is new or has big changes  -->
Before:
![image](https://user-images.githubusercontent.com/63985172/136717685-a69460ea-0ef2-4db3-9ede-fd2029f301c2.png)

After:
![image](https://user-images.githubusercontent.com/63985172/136717697-f20f2b99-6636-44a8-82dd-99a0c0b6b9bc.png)


## Reviewer checklist

- [ ] I have run the code (if applicable)
- [ ] I have reviewed and run any tests (if applicable)
