### PR TITLE
feat:CO-78 : Show only terms corresponding to the product

### DIFF
--- a/src/App-au.vue
+++ b/src/App-au.vue
@@ -42,7 +42,7 @@ export default defineComponent({
     return {
       cards: [{}],
       products: [{}],
-      terms: '',
+      terms: {},
     }
   },
   computed: {

--- a/src/App-nz.vue
+++ b/src/App-nz.vue
@@ -44,7 +44,7 @@ export default defineComponent({
     return {
       cards: [{}],
       products: [{}],
-      terms: '',
+      terms: {},
     }
   },
   computed: {

--- a/src/components/tabs/Tabs.stories.ts
+++ b/src/components/tabs/Tabs.stories.ts
@@ -1,6 +1,7 @@
 import { Story, Meta } from '@storybook/vue3'
 import Tabs from 'src/components/tabs/Tabs.vue'
 import type TabsProps from 'src/models/Tabs'
+import ProductEnum from 'src/models/enums/ProductEnum'
 
 export default {
   title: 'Tabs/Tabs',
@@ -25,7 +26,7 @@ export const Default = Template.bind({})
 Default.args = {
   tabs: [
     {
-      productType: 'Standard',
+      productType: ProductEnum.Standard,
       productItems: [
         {
           id: '18months',
@@ -73,7 +74,7 @@ WithDefaultTabId.args = {
   defaultTabId: '24months',
   tabs: [
     {
-      productType: 'Standard',
+      productType: ProductEnum.Standard,
       productItems: [
         {
           id: '18months',

--- a/src/models/Response.ts
+++ b/src/models/Response.ts
@@ -18,6 +18,12 @@ export interface Product {
   remainderInterestPeriodMontlyRepayment: number
 }
 
+export interface Terms {
+  standard?: string
+  hybrid?: string
+  fixed?: string
+}
+
 export interface WidgetResponseBody {
   products: Product[]
   cards: Card[]

--- a/src/models/Tabs.ts
+++ b/src/models/Tabs.ts
@@ -1,3 +1,5 @@
+import ProductEnum from 'src/models/enums/ProductEnum'
+
 export interface ContentsProps {
   name: string
   value: string
@@ -9,7 +11,7 @@ export interface TabItemProps {
 }
 
 export interface ProductItemProps {
-  productType: string
+  productType: ProductEnum
   productItems: TabItemProps[]
 }
 

--- a/src/models/Terms.ts
+++ b/src/models/Terms.ts
@@ -1,0 +1,7 @@
+export interface TermProps {
+  standard?: string
+  hybrid?: string
+  fixed?: string
+}
+
+export default TermProps

--- a/src/models/Terms.ts
+++ b/src/models/Terms.ts
@@ -1,7 +1,5 @@
-export interface TermProps {
-  standard?: string
-  hybrid?: string
-  fixed?: string
-}
+import { Terms } from 'src/models/Response'
+
+export type TermProps = Terms
 
 export default TermProps

--- a/src/models/enums/ProductEnum.ts
+++ b/src/models/enums/ProductEnum.ts
@@ -1,0 +1,7 @@
+export enum ProductEnum {
+  Standard = 'standard',
+  Hybrid = 'hybrid',
+  Fixed = 'fixed',
+}
+
+export default ProductEnum

--- a/src/modules/DialogOverlay.vue
+++ b/src/modules/DialogOverlay.vue
@@ -12,10 +12,10 @@
       <slot name="header" />
     </template>
     <template #body>
-      <Tabs :tabs="getPrimaryProductData(tabsData)">
+      <Tabs :tabs="getDataForProduct()">
         <template #default="{ activeTabId }">
           <Tab
-            v-for="tab in getPrimaryProductData(tabsData)"
+            v-for="tab in getDataForProduct()"
             :key="tab.id"
             :tab-id="tab.id"
             :active-tab-id="activeTabId"
@@ -25,7 +25,7 @@
         </template>
       </Tabs>
       <slot name="footer" />
-      <Accordion id="widget-terms" :content="accordionData">
+      <Accordion id="widget-terms" :content="getTermsForProduct()">
         Terms & Conditions
       </Accordion>
     </template>
@@ -40,6 +40,8 @@ import Tabs from 'src/components/tabs/Tabs.vue'
 import Tab from 'src/components/tabs/Tab.vue'
 import DataList from 'src/components/tabs/DataList.vue'
 import { TabItemProps, ContentsProps, ProductItemProps } from 'src/models/Tabs'
+import { TermProps } from 'src/models/Terms'
+import ProductEnum from 'src/models/enums/ProductEnum'
 
 export default defineComponent({
   name: 'DialogOverlay',
@@ -63,7 +65,7 @@ export default defineComponent({
       required: true,
     },
     accordionData: {
-      type: String,
+      type: Object as () => TermProps,
       required: true,
     },
   },
@@ -72,12 +74,25 @@ export default defineComponent({
     toggleDialog() {
       this.$emit('toggle-dialog')
     },
-    getPrimaryProductData(data: ProductItemProps[]): TabItemProps[] {
-      return data[0].productItems
+    selectProductType(): ProductEnum {
+      const productType = this.tabsData[0].productType
+      return productType
+    },
+    getDataForProduct(): TabItemProps[] | undefined {
+      const productType = this.selectProductType()
+      const productData = this.tabsData.find(
+        product => product.productType === productType
+      )
+      return productData?.productItems
+    },
+    getTermsForProduct() {
+      const productType = this.selectProductType()
+      const productTypeLower = productType?.toLowerCase() as ProductEnum
+      return this.accordionData[productTypeLower]
     },
     tabsContents(id: string): ContentsProps[] | undefined {
-      const productData = this.getPrimaryProductData(this.tabsData)
-      return productData.find(item => item.id === id)?.contents
+      const productData = this.getDataForProduct()
+      return productData?.find(item => item.id === id)?.contents
     },
   },
 })

--- a/src/styles/widget.scss
+++ b/src/styles/widget.scss
@@ -24,7 +24,7 @@
     margin-left: 8px;
 
     .button {
-      margin-top: 4px;
+      margin-top: 8px;
     }
   }
 
@@ -34,6 +34,10 @@
     width: 100%;
     justify-content: space-between;
     margin-right: 8px;
+
+    .button {
+      margin-top: 4px;
+    }
   }
 
   &__text {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -124,7 +124,7 @@ export const getProductData = (productsData: Product[]): ProductItemProps[] => {
         contents: getProductContent(productItem),
       })
     } else {
-      if (productItem.type in ProductEnum)
+      if (Object.values(ProductEnum).includes(productItem.type as ProductEnum))
         acc.push({
           productType: productItem.type as ProductEnum,
           productItems: [

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -6,6 +6,7 @@ import { ContentsProps, ProductItemProps } from 'src/models/Tabs'
 import CardProps from 'src/models/Card'
 import { ProductLanguage } from 'src/lang/ResponseLanguage'
 import ThemeEnum from 'src/models/enums/ThemeEnum'
+import ProductEnum from 'src/models/enums/ProductEnum'
 
 export const getCurrentScript = (): HTMLOrSVGScriptElement =>
   document.currentScript ||
@@ -123,16 +124,18 @@ export const getProductData = (productsData: Product[]): ProductItemProps[] => {
         contents: getProductContent(productItem),
       })
     } else {
-      acc.push({
-        productType: productItem.type,
-        productItems: [
-          {
-            id: productItem.id,
-            label: createTabLabel(productItem.termPeriod),
-            contents: getProductContent(productItem),
-          },
-        ],
-      })
+      if (productItem.type in ProductEnum)
+        acc.push({
+          productType: productItem.type as ProductEnum,
+          productItems: [
+            {
+              id: productItem.id,
+              label: createTabLabel(productItem.termPeriod),
+              contents: getProductContent(productItem),
+            },
+          ],
+        })
+      else throw new Error(`Unknown product type, ${productItem.type}`)
     }
     return acc
   }, [] as ProductItemProps[])

--- a/src/widgets/WidgetMainFarmers.vue
+++ b/src/widgets/WidgetMainFarmers.vue
@@ -38,6 +38,7 @@ import ThemeEnum from 'src/models/enums/ThemeEnum'
 import LanguageCodeEnum from 'src/models/enums/LanguageCodeEnum'
 import CardProps from 'src/models/Card'
 import { ProductItemProps } from 'src/models/Tabs'
+import { TermProps } from 'src/models/Terms'
 import WidgetContent from 'src/modules/WidgetContent.vue'
 import CardsLogo from 'src/modules/CardsLogo.vue'
 import DialogOverlay from 'src/modules/DialogOverlay.vue'
@@ -63,7 +64,7 @@ export default defineComponent({
       required: true,
     },
     terms: {
-      type: String,
+      type: Object as () => TermProps,
       required: true,
     },
   },

--- a/src/widgets/WidgetMainHumm90.vue
+++ b/src/widgets/WidgetMainHumm90.vue
@@ -64,6 +64,7 @@ import ThemeEnum from 'src/models/enums/ThemeEnum'
 import LanguageCodeEnum from 'src/models/enums/LanguageCodeEnum'
 import CardProps from 'src/models/Card'
 import { ProductItemProps } from 'src/models/Tabs'
+import { TermProps } from 'src/models/Terms'
 import WidgetContent from 'src/modules/WidgetContent.vue'
 import DialogOverlay from 'src/modules/DialogOverlay.vue'
 import ApplyCard from 'src/modules/ApplyCard.vue'
@@ -92,7 +93,7 @@ export default defineComponent({
       required: true,
     },
     terms: {
-      type: String,
+      type: Object as () => TermProps,
       required: true,
     },
   },

--- a/src/widgets/WidgetMainHummGroup.vue
+++ b/src/widgets/WidgetMainHummGroup.vue
@@ -37,6 +37,7 @@ import ThemeEnum from 'src/models/enums/ThemeEnum'
 import LanguageCodeEnum from 'src/models/enums/LanguageCodeEnum'
 import CardProps from 'src/models/Card'
 import { ProductItemProps } from 'src/models/Tabs'
+import { TermProps } from 'src/models/Terms'
 import WidgetContent from 'src/modules/WidgetContent.vue'
 import DialogOverlay from 'src/modules/DialogOverlay.vue'
 
@@ -60,7 +61,7 @@ export default defineComponent({
       required: true,
     },
     terms: {
-      type: String,
+      type: Object as () => TermProps,
       required: true,
     },
   },

--- a/src/widgets/WidgetMainQmc.vue
+++ b/src/widgets/WidgetMainQmc.vue
@@ -58,6 +58,7 @@ import ThemeEnum from 'src/models/enums/ThemeEnum'
 import LanguageCodeEnum from 'src/models/enums/LanguageCodeEnum'
 import CardProps from 'src/models/Card'
 import { ProductItemProps } from 'src/models/Tabs'
+import { TermProps } from 'src/models/Terms'
 import WidgetContent from 'src/modules/WidgetContent.vue'
 import CardsLogo from 'src/modules/CardsLogo.vue'
 import DialogOverlay from 'src/modules/DialogOverlay.vue'
@@ -87,7 +88,7 @@ export default defineComponent({
       required: true,
     },
     terms: {
-      type: String,
+      type: Object as () => TermProps,
       required: true,
     },
   },


### PR DESCRIPTION
## PR Area

<!-- Check areas your PR covers using "x", REMOVE others -->

- [x] Frontend

## Type of change

_What kind of change does this PR introduce?_

<!-- Check the ones that apply to this PR using "x", REMOVE others -->

- [x] Feature

## Description

<!-- Add a few bullets * describing your changes -->
* BE returns terms for each type of product
> "terms": {
        "standard": "XX months interest free* on in-store/online only purchases $XX & over. blah blah",
        "hybrid": "No payments & no interest until <month/Year>* on in-store purchases $XX & over. blah blah",
        "fixed": "Insert Sample T&C's for Hybrid here\n"
    },
* Since the widget overlay can only show one product type at a time, we should only show the terms corresponding to the product being displayed
* Piggyback client request - when the widget is shown with the "Learn more" button beneath the title, use 8px margin-top

## Security & risks

<!-- Describe the risks that apply. -->

- [ ] Adds new third party libraries
- [ ] Adds new `.env` variables
- [ ] Integrates with Third-party apis (dependency must be resilient)
- [ ] Has specific [OWASP security concerns](https://owasp.org/www-project-top-ten/) - list them: (also see [Fixing OWASP Top 10](https://nodegoat.herokuapp.com/tutorial))

## Pre-publish checklist

<!--
Include the Jira ticket name (if any) with a hyphen.

If the change spans across multiple packages, please include the general scope area: frontend/backend.
If the change spans across multiple scopes just include the word "multiple" into the scope
-->

- [x] I have assigned myself to the ticket
- [x] I have performed a self-review of my code
- [x] I have performed relevant browser testing
- [ ] I have performed keyboard testing of new or modified interactive components

#### Evidence screenshots

<!-- Please drag and drop to upload evidence screenshots of UI that is new or has big changes  -->
Before:
![image](https://user-images.githubusercontent.com/63985172/136728137-21bf8419-48b6-4496-826b-223e8637424b.png)

After:
![image](https://user-images.githubusercontent.com/63985172/136727928-bd9dad3c-af3d-4403-bb8b-1d3637bf1dc2.png)

Client request - when the widget is shown with the "Learn more" button beneath the title, use 8px margin-top

Before:
![image](https://user-images.githubusercontent.com/63985172/136740736-66c13401-0bd0-43b7-8047-8bd9ed480443.png)

After:
![image](https://user-images.githubusercontent.com/63985172/136740618-f0c2db93-4ebc-4947-b113-88e7833f9df5.png)


## Reviewer checklist

- [ ] I have run the code (if applicable)
- [ ] I have reviewed and run any tests (if applicable)
