### PR TITLE
feat:CO-98: button opacity based on darkMode + remove bold button in QMC

### DIFF
--- a/src/App-au.vue
+++ b/src/App-au.vue
@@ -7,6 +7,7 @@
           :product-price="productPrice"
           :lang="lang"
           :theme="theme"
+          :is-dark="darkMode"
           :is-size-large="isSizeLarge"
           :cards="cards"
           :products="products"

--- a/src/App-nz.vue
+++ b/src/App-nz.vue
@@ -7,6 +7,7 @@
           :product-price="productPrice"
           :lang="lang"
           :theme="theme"
+          :is-dark="darkMode"
           :is-size-large="isSizeLarge"
           :cards="cards"
           :products="products"

--- a/src/modules/WidgetContent.vue
+++ b/src/modules/WidgetContent.vue
@@ -7,11 +7,7 @@
           <slot name="title" />
           <slot name="subtitle" />
         </div>
-        <Button
-          :button-color="buttonColor"
-          :is-bold="isButtonBold"
-          @click="toggleDialog"
-        >
+        <Button :button-color="buttonColor" @click="toggleDialog">
           {{ buttonLabel }}
         </Button>
       </div>

--- a/src/modules/WidgetContent.vue
+++ b/src/modules/WidgetContent.vue
@@ -7,7 +7,11 @@
           <slot name="title" />
           <slot name="subtitle" />
         </div>
-        <Button :button-color="buttonColor" @click="toggleDialog">
+        <Button
+          :button-color="buttonColor"
+          :is-bold="isButtonBold"
+          @click="toggleDialog"
+        >
           {{ buttonLabel }}
         </Button>
       </div>
@@ -53,7 +57,10 @@ export default defineComponent({
       type: String,
       default: '1',
     },
-    isButtonBold: Boolean,
+    isButtonBold: {
+      type: Boolean,
+      default: false,
+    },
   },
   emits: ['toggle-dialog', 'close-widget'],
   methods: {

--- a/src/widgets/WidgetMainHumm90.vue
+++ b/src/widgets/WidgetMainHumm90.vue
@@ -3,7 +3,7 @@
     :is-size-large="isSizeLarge"
     :is-widget-open="isWidgetOpen"
     button-color="var(--color-3)"
-    icon-opacity="0.3"
+    :icon-opacity="isDark ? '0.8' : '0.3'"
     button-label="LEARN MORE"
     @toggle-dialog="isDialogOpen = true"
     @close-widget="isWidgetOpen = false"
@@ -69,6 +69,10 @@ export default defineComponent({
     productPrice: Number,
     lang: String as () => LanguageCodeEnum,
     theme: String as () => ThemeEnum,
+    isDark: {
+      type: Boolean,
+      default: false,
+    },
     isSizeLarge: {
       type: Boolean,
       required: true,

--- a/src/widgets/WidgetMainQmc.vue
+++ b/src/widgets/WidgetMainQmc.vue
@@ -4,7 +4,7 @@
     :is-widget-open="isWidgetOpen"
     :is-button-bold="true"
     button-color="var(--color-3)"
-    icon-opacity="0.3"
+    :icon-opacity="isDark ? '0.8' : '0.3'"
     @toggle-dialog="isDialogOpen = true"
     @close-widget="isWidgetOpen = false"
   >
@@ -74,6 +74,10 @@ export default defineComponent({
     productPrice: Number,
     lang: String as () => LanguageCodeEnum,
     theme: String as () => ThemeEnum,
+    isDark: {
+      type: Boolean,
+      default: false,
+    },
     cards: {
       type: Array as () => CardProps[],
       required: true,

--- a/src/widgets/WidgetMainQmc.vue
+++ b/src/widgets/WidgetMainQmc.vue
@@ -2,7 +2,6 @@
   <WidgetContent
     :is-size-large="isSizeLarge"
     :is-widget-open="isWidgetOpen"
-    :is-button-bold="true"
     button-color="var(--color-3)"
     :icon-opacity="isDark ? '0.8' : '0.3'"
     @toggle-dialog="isDialogOpen = true"


### PR DESCRIPTION
## PR Area

<!-- Check areas your PR covers using "x", REMOVE others -->

- [x] Frontend

## Type of change

_What kind of change does this PR introduce?_

<!-- Check the ones that apply to this PR using "x", REMOVE others -->

- [x] Feature

## Description

<!-- Add a few bullets * describing your changes -->
* Close button's opacity is based on the whether the widget is in dark mode or not
  * if darkMode is true, opacity = 0.8
  * if darkMode is false, opacity = 0.3
Design:
![image](https://user-images.githubusercontent.com/63985172/140668612-e397fcb3-b725-4411-9e02-a4fb7aa7b39c.png)
![image](https://user-images.githubusercontent.com/63985172/140668601-dbaa84f4-1df5-4793-93b8-c2fdba072a5f.png)
Actual:
![image](https://user-images.githubusercontent.com/63985172/140668578-a3d52064-e372-4a33-b09c-400fab7f6ee6.png)

*  In QMC Theme, remove `is-button-bold` prop since it is no longer required by the design
Design:
![image](https://user-images.githubusercontent.com/63985172/140668384-b1d937fc-4502-45e6-977d-002d7a98b925.png)
Previous design:
![image](https://user-images.githubusercontent.com/63985172/140668433-a582e1fe-cf8f-4709-98fa-d9043d6a3d79.png)
Actual now:
![image](https://user-images.githubusercontent.com/63985172/140668449-849342ed-8049-45e0-8bec-71ce54c00208.png)


## Security & risks

<!-- Describe the risks that apply. -->

- [ ] Adds new third party libraries
- [ ] Adds new `.env` variables
- [ ] Integrates with Third-party apis (dependency must be resilient)
- [ ] Has specific [OWASP security concerns](https://owasp.org/www-project-top-ten/) - list them: (also see [Fixing OWASP Top 10](https://nodegoat.herokuapp.com/tutorial))

## Pre-publish checklist

<!--
Include the Jira ticket name (if any) with a hyphen.

If the change spans across multiple packages, please include the general scope area: frontend/backend.
If the change spans across multiple scopes just include the word "multiple" into the scope
-->

- [x] I have assigned myself to the ticket
- [x] I have performed a self-review of my code
- [x] I have performed relevant browser testing
- [ ] I have performed keyboard testing of new or modified interactive components

#### Evidence screenshots

<!-- Please drag and drop to upload evidence screenshots of UI that is new or has big changes  -->

## Reviewer checklist

- [ ] I have run the code (if applicable)
- [ ] I have reviewed and run any tests (if applicable)
