### PR TITLE
feat:CO-102: Dynamic overlay heading and remove tab-control when only one product variant exists

### DIFF
--- a/src/components/tabs/Tabs.vue
+++ b/src/components/tabs/Tabs.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="tabs">
-    <ul class="tabs__controls" role="tablist">
+    <ul v-if="tabs.length > 1" class="tabs__controls" role="tablist">
       <li
         v-for="tab in tabs"
         :key="tab.id"

--- a/src/modules/DialogOverlay.vue
+++ b/src/modules/DialogOverlay.vue
@@ -14,10 +14,10 @@
       <slot name="header" />
     </template>
     <template #body>
-      <Tabs :tabs="getPrimaryProductData()">
+      <Tabs :tabs="getProductData()">
         <template #default="{ activeTabId }">
           <Tab
-            v-for="tab in getPrimaryProductData()"
+            v-for="tab in getProductData()"
             :key="tab.id"
             :tab-id="tab.id"
             :active-tab-id="activeTabId"
@@ -76,8 +76,8 @@ export default defineComponent({
       type: Number,
       required: true,
     },
-    productsData: {
-      type: Array as () => ProductItemProps[],
+    product: {
+      type: Object as () => ProductItemProps,
       required: true,
     },
     accordionTitle: {
@@ -89,7 +89,7 @@ export default defineComponent({
       required: true,
     },
   },
-  emits: ['toggle-dialog'],
+  emits: ['toggle-dialog', 'primary-products'],
   data() {
     return {
       fieldBreakdownAu: [
@@ -111,30 +111,22 @@ export default defineComponent({
     toggleDialog() {
       this.$emit('toggle-dialog')
     },
-    getPrimaryProduct(): ProductItemProps {
-      return this.productsData[0]
-    },
-    getPrimaryProductType(): ProductEnum {
-      const productType = this.getPrimaryProduct().productType
+    getProductType(): ProductEnum {
+      const productType = this.product.productType
       return productType
     },
-    getPrimaryProductData(): TabItemProps[] {
-      const productType = this.getPrimaryProductType()
-      const productData = this.productsData.find(
-        product => product.productType === productType
-      )
-      if (!productData)
-        throw new Error(`No data found corresponding to ${productType}`)
-      return productData.productItems
+    getProductData(): TabItemProps[] {
+      const productData = this.product.productItems
+      return productData
     },
-    getOverlayTitle() {
-      const productType = this.getPrimaryProductType()
+    getOverlayTitle(): string {
+      const productType = this.getProductType()
       switch (productType) {
         case ProductEnum.LongTermInterestFree:
           return 'Long Term Finance Offer'
         case ProductEnum.PaymentHoliday: {
           const interestFreePeriod = getProductValueByKey(
-            this.getPrimaryProduct(),
+            this.product,
             'interestFreePeriod'
           )
           return `${interestFreePeriod} ${pluralize(
@@ -237,7 +229,7 @@ export default defineComponent({
       return contentWithUnit
     },
     tabsContents(id: string): ContentsProps[] {
-      const productData = this.getPrimaryProductData()
+      const productData = this.getProductData()
       const productContents = productData?.find(item => item.id === id)
         ?.contents
 

--- a/src/modules/ExistingCard.vue
+++ b/src/modules/ExistingCard.vue
@@ -46,7 +46,7 @@ export default defineComponent({
         case ProductEnum.PaymentHoliday:
           return 'Payment Holiday'
         default:
-          return 'interest free'
+          return this.product.productType
       }
     },
   },

--- a/src/modules/ExistingCard.vue
+++ b/src/modules/ExistingCard.vue
@@ -13,7 +13,9 @@
   <ol class="mc__list">
     <slot name="list">
       <li>Add the item and continue to checkout</li>
-      <li>Choose <strong>interest-free</strong> as your payment option</li>
+      <li>
+        Choose <strong>{{ getPaymentOption() }}</strong> as your payment option
+      </li>
       <li>Enter your card details and choose a plan listed below:</li>
     </slot>
   </ol>
@@ -22,11 +24,31 @@
 <script lang="ts">
 import { defineComponent } from 'vue'
 import CardsList from 'src/modules/CardsList.vue'
+import { ProductItemProps } from 'src/models/Tabs'
+import ProductEnum from 'src/models/enums/ProductEnum'
 
 export default defineComponent({
   name: 'ExistingCard',
   components: {
     CardsList,
+  },
+  props: {
+    product: {
+      type: Object as () => ProductItemProps,
+      required: true,
+    },
+  },
+  methods: {
+    getPaymentOption(): string {
+      switch (this.product.productType) {
+        case ProductEnum.LongTermInterestFree:
+          return 'Long Term Finance'
+        case ProductEnum.PaymentHoliday:
+          return 'Payment Holiday'
+        default:
+          return 'interest free'
+      }
+    },
   },
 })
 </script>

--- a/src/widgets/WidgetMainFarmers.vue
+++ b/src/widgets/WidgetMainFarmers.vue
@@ -30,12 +30,12 @@
     :button-close-label="buttonCloseLabel"
     :lang="lang"
     :product-price="productPrice"
-    :products-data="products"
+    :product="displayedProduct"
     :accordion-data="terms"
     @toggle-dialog="isDialogOpen = false"
   >
     <template #header>
-      <ExistingCard>
+      <ExistingCard :product="displayedProduct">
         <template #cards>
           <Card v-for="card in getApplyCards" :key="card.id" size="lg">
             <img :src="card.src" :alt="card.alt" />
@@ -93,6 +93,7 @@ export default defineComponent({
     return {
       isWidgetOpen: true,
       isDialogOpen: false,
+      displayedProduct: this.products[0],
       buttonCloseLabel: 'Close',
       Theme: ThemeEnum,
     }

--- a/src/widgets/WidgetMainFarmers.vue
+++ b/src/widgets/WidgetMainFarmers.vue
@@ -30,7 +30,7 @@
     :button-close-label="buttonCloseLabel"
     :lang="lang"
     :product-price="productPrice"
-    :tabs-data="products"
+    :products-data=="products"
     :accordion-data="terms"
     @toggle-dialog="isDialogOpen = false"
   >

--- a/src/widgets/WidgetMainFarmers.vue
+++ b/src/widgets/WidgetMainFarmers.vue
@@ -30,7 +30,7 @@
     :button-close-label="buttonCloseLabel"
     :lang="lang"
     :product-price="productPrice"
-    :products-data=="products"
+    :products-data="products"
     :accordion-data="terms"
     @toggle-dialog="isDialogOpen = false"
   >

--- a/src/widgets/WidgetMainHumm90.vue
+++ b/src/widgets/WidgetMainHumm90.vue
@@ -25,13 +25,13 @@
     :button-close-label="buttonCloseLabel"
     :lang="lang"
     :product-price="productPrice"
-    :products-data="products"
+    :product="displayedProduct"
     accordion-title="TERMS & CONDITIONS"
     :accordion-data="terms"
     @toggle-dialog="isDialogOpen = false"
   >
     <template #header>
-      <ExistingCard>
+      <ExistingCard :product="displayedProduct">
         <template #cards>
           <Card v-for="card in getApplyCards" :key="card.id" size="lg">
             <img :src="card.src" :alt="card.alt" />
@@ -95,6 +95,7 @@ export default defineComponent({
     return {
       isWidgetOpen: true,
       isDialogOpen: false,
+      displayedProduct: {} as ProductItemProps,
       buttonCloseLabel: 'Close',
       Theme: ThemeEnum,
       title: '',
@@ -107,9 +108,10 @@ export default defineComponent({
   },
   created() {
     this.createTitle()
+    this.setProduct()
   },
   methods: {
-    getLongTermInterestFreeTitle() {
+    getLongTermInterestFreeTitle(): string {
       const interestFreePeriod = getProductValueByKey(
         this.products[0],
         'interestFreePeriod'
@@ -125,6 +127,9 @@ export default defineComponent({
         case ProductEnum.LongTermInterestFree:
           this.title = this.getLongTermInterestFreeTitle()
       }
+    },
+    setProduct() {
+      this.displayedProduct = this.products[0]
     },
   },
 })

--- a/src/widgets/WidgetMainHumm90.vue
+++ b/src/widgets/WidgetMainHumm90.vue
@@ -25,7 +25,7 @@
     :button-close-label="buttonCloseLabel"
     :lang="lang"
     :product-price="productPrice"
-    :tabs-data="products"
+    :products-data="products"
     accordion-title="TERMS & CONDITIONS"
     :accordion-data="terms"
     @toggle-dialog="isDialogOpen = false"

--- a/src/widgets/WidgetMainHummGroup.vue
+++ b/src/widgets/WidgetMainHummGroup.vue
@@ -24,7 +24,7 @@
     id="widget-dialog"
     :is-dialog-open="isDialogOpen"
     :button-close-label="buttonCloseLabel"
-    :tabs-data="products"
+    :products-data="products"
     :accordion-data="terms"
     @toggle-dialog="isDialogOpen = false"
   >

--- a/src/widgets/WidgetMainHummGroup.vue
+++ b/src/widgets/WidgetMainHummGroup.vue
@@ -24,7 +24,7 @@
     id="widget-dialog"
     :is-dialog-open="isDialogOpen"
     :button-close-label="buttonCloseLabel"
-    :products-data="products"
+    :product="displayedProduct"
     :accordion-data="terms"
     @toggle-dialog="isDialogOpen = false"
   >
@@ -73,6 +73,7 @@ export default defineComponent({
     return {
       isWidgetOpen: true,
       isDialogOpen: false,
+      displayedProduct: this.products[0],
       buttonCloseLabel: 'Close',
       Theme: ThemeEnum,
     }

--- a/src/widgets/WidgetMainQmc.vue
+++ b/src/widgets/WidgetMainQmc.vue
@@ -30,12 +30,12 @@
     :button-close-label="buttonCloseLabel"
     :lang="lang"
     :product-price="productPrice"
-    :products-data="products"
+    :product="displayedProduct"
     :accordion-data="terms"
     @toggle-dialog="isDialogOpen = false"
   >
     <template #header>
-      <ExistingCard>
+      <ExistingCard :product="displayedProduct">
         <template #cards>
           <Card v-for="card in getApplyCards" :key="card.id" size="lg">
             <img :src="card.src" :alt="card.alt" />
@@ -102,7 +102,7 @@ export default defineComponent({
     isDialogOpen: boolean
     buttonCloseLabel: string
     Theme: typeof ThemeEnum
-    primaryProduct: ProductItemProps
+    displayedProduct: ProductItemProps
     cardAccountFee: number | undefined
     cardStandardInterestRate: number | undefined
     title: string
@@ -113,7 +113,7 @@ export default defineComponent({
       isDialogOpen: false,
       buttonCloseLabel: 'Close',
       Theme: ThemeEnum,
-      primaryProduct: {} as ProductItemProps,
+      displayedProduct: {} as ProductItemProps,
       cardAccountFee: undefined,
       cardStandardInterestRate: undefined,
       title: '',
@@ -129,16 +129,15 @@ export default defineComponent({
     },
   },
   created() {
-    this.getPrimaryProduct()
+    this.setProduct()
     this.getCardAccountFee()
     this.getCardStandardInterestRate()
     this.createTitle()
     this.createSubtitle()
   },
   methods: {
-    getPrimaryProduct() {
-      this.primaryProduct.productType = this.products[0].productType
-      this.primaryProduct.productItems = this.products[0].productItems
+    setProduct() {
+      this.displayedProduct = this.products[0]
     },
     getCardAccountFee() {
       this.cardAccountFee = this.cards.find(
@@ -152,11 +151,11 @@ export default defineComponent({
     },
     getLongTermInterestFreeTitle() {
       const interestFreePeriod = getProductValueByKey(
-        this.primaryProduct,
+        this.displayedProduct,
         'interestFreePeriod'
       ) as number
       const indicativeMinMonthly = getProductValueByKey(
-        this.primaryProduct,
+        this.displayedProduct,
         'indicativeMinMonthly'
       ) as number
       return `${interestFreePeriod} ${pluralize(
@@ -170,7 +169,7 @@ export default defineComponent({
     },
     getPaymentHolidayTitle() {
       const interestFreePeriod = getProductValueByKey(
-        this.primaryProduct,
+        this.displayedProduct,
         'interestFreePeriod'
       ) as number
       return `${interestFreePeriod} ${pluralize(
@@ -194,7 +193,7 @@ export default defineComponent({
       return `Standard Interest Rate ${this.cardStandardInterestRate}% applies at the end of the interest free period. $${establishmentFee} Establishment Fee or $${advancedFee} Advance Fee applies. $${this.cardAccountFee} annual Account Fee. Ts&Cs apply.`
     },
     createTitle() {
-      switch (this.primaryProduct.productType) {
+      switch (this.displayedProduct.productType) {
         case ProductEnum.LongTermInterestFree:
           this.title = this.getLongTermInterestFreeTitle()
           break
@@ -205,14 +204,14 @@ export default defineComponent({
     },
     createSubtitle() {
       const establishmentFee = getProductValueByKey(
-        this.primaryProduct,
+        this.displayedProduct,
         'establishmentFee'
       ) as number
       const advancedFee = getProductValueByKey(
-        this.primaryProduct,
+        this.displayedProduct,
         'advancedFee'
       ) as number
-      switch (this.primaryProduct.productType) {
+      switch (this.displayedProduct.productType) {
         case ProductEnum.LongTermInterestFree:
           this.subtitle = this.getLongTermInterestFreeSubtitle(
             establishmentFee,

--- a/src/widgets/WidgetMainQmc.vue
+++ b/src/widgets/WidgetMainQmc.vue
@@ -30,7 +30,7 @@
     :button-close-label="buttonCloseLabel"
     :lang="lang"
     :product-price="productPrice"
-    :tabs-data="products"
+    :products-data="products"
     :accordion-data="terms"
     @toggle-dialog="isDialogOpen = false"
   >


### PR DESCRIPTION
## PR Area

<!-- Check areas your PR covers using "x", REMOVE others -->

- [x] Frontend

## Type of change

_What kind of change does this PR introduce?_

<!-- Check the ones that apply to this PR using "x", REMOVE others -->

- [x] Feature

## Description

<!-- Add a few bullets * describing your changes -->
* Overlay title use to be static ("Interest-free Payment"). It is now based on the product type:
  * For LongTermInterestFree, the title will be 'Long Term Finance Offer'
  * For PaymentHoliday, the title will be `<interestFreePeriod> Month(s) No Payments & No Interest`
* When a product doesn't have multiple variants (different termPeriod), then there is no need to show the product details in tabs
Before:
![image](https://user-images.githubusercontent.com/63985172/140859658-da26513a-7ce0-4326-84f9-ee7ccafbe50f.png)
After:
![image](https://user-images.githubusercontent.com/63985172/140858954-08d48574-427e-4f85-8d42-2fcca72758ed.png)
* Dynamic payment option text in `ExistingCard.vue` component. This required moving product selection function (`setProduct`) one level up from `DialogOverlay.vue` to its parent component (`WidgetMainHumm90.vue`, `WidgetMainQmc.vue`, `WidgetMainFarmers.vue`, and `WidgetMainHummGroup.vue`)
Now:
![image](https://user-images.githubusercontent.com/63985172/140860218-a48813c1-f9ed-4d18-b7e0-9610fc610d8a.png)

## Security & risks

<!-- Describe the risks that apply. -->

- [ ] Adds new third party libraries
- [ ] Adds new `.env` variables
- [ ] Integrates with Third-party apis (dependency must be resilient)
- [ ] Has specific [OWASP security concerns](https://owasp.org/www-project-top-ten/) - list them: (also see [Fixing OWASP Top 10](https://nodegoat.herokuapp.com/tutorial))

## Pre-publish checklist

<!--
Include the Jira ticket name (if any) with a hyphen.

If the change spans across multiple packages, please include the general scope area: frontend/backend.
If the change spans across multiple scopes just include the word "multiple" into the scope
-->

- [x] I have assigned myself to the ticket
- [x] I have performed a self-review of my code
- [ ] I have performed relevant browser testing
- [ ] I have performed keyboard testing of new or modified interactive components

#### Evidence screenshots

<!-- Please drag and drop to upload evidence screenshots of UI that is new or has big changes  -->

## Reviewer checklist

- [ ] I have run the code (if applicable)
- [ ] I have reviewed and run any tests (if applicable)
